### PR TITLE
Refactor shared.js file

### DIFF
--- a/api/routes/exercises/shared.js
+++ b/api/routes/exercises/shared.js
@@ -63,6 +63,8 @@ const errorMessages = {
 
 const supportedLanguages = ["en", "pt"];
 const defaultLanguage = "en";
+const defaultPage = 0;
+const defaultLimit = 50;
 
 const validFields = [
   "force",
@@ -76,6 +78,7 @@ const validFields = [
   "images",
   "name",
 ];
+const validFieldSet = new Set(validFields);
 
 const filterableFields = [
   "primaryMuscles",
@@ -86,36 +89,57 @@ const filterableFields = [
   "category",
 ];
 
+const languageSet = new Set(supportedLanguages);
+const excludedExtractedValues = new Set(supportedLanguages);
+const localizedExerciseFields = [
+  "name",
+  "force",
+  "level",
+  "mechanic",
+  "equipment",
+  "primaryMuscles",
+  "secondaryMuscles",
+  "instructions",
+  "category",
+];
+
 const fuseOptions = {
   includeScore: true,
   threshold: 0.4,
   keys: ["name.en", "name.pt"],
 };
 
+const defaultImageFormatter = (exercise) => exercise.images;
+const formatValidFields = () => `${validFields.join(", ")}.`;
+const validationError = (message, extraBody = {}) => ({
+  error: {
+    status: 400,
+    body: {
+      message,
+      ...extraBody,
+    },
+  },
+});
+
 const getHeaderLanguage = (acceptLanguage = "") =>
   acceptLanguage.split(",")[0]?.split("-")[0] || defaultLanguage;
 
 const getErrorLanguage = (requestedLang, acceptLanguage) => {
-  if (supportedLanguages.includes(requestedLang)) {
+  if (languageSet.has(requestedLang)) {
     return requestedLang;
   }
 
   const headerLanguage = getHeaderLanguage(acceptLanguage);
-  return supportedLanguages.includes(headerLanguage) ? headerLanguage : defaultLanguage;
+  return languageSet.has(headerLanguage) ? headerLanguage : defaultLanguage;
 };
 
 const parseLanguage = (requestedLang, acceptLanguage) => {
   const lang = requestedLang || defaultLanguage;
 
-  if (!supportedLanguages.includes(lang)) {
-    return {
-      error: {
-        status: 400,
-        body: {
-          message: errorMessages.invalidLang[getErrorLanguage(lang, acceptLanguage)],
-        },
-      },
-    };
+  if (!languageSet.has(lang)) {
+    return validationError(
+      errorMessages.invalidLang[getErrorLanguage(lang, acceptLanguage)],
+    );
   }
 
   return { lang };
@@ -127,29 +151,21 @@ const parseFields = (rawFields, lang) => {
   }
 
   if (rawFields === "") {
-    return {
-      error: {
-        status: 400,
-        body: {
-          message: `${errorMessages.invalideParametters[lang]} ${validFields.join(", ")}.`,
-        },
-      },
-    };
+    return validationError(
+      `${errorMessages.invalideParametters[lang]} ${formatValidFields()}`,
+    );
   }
 
   const fields = rawFields.split(",").map((field) => field.trim());
-  const invalidFields = fields.filter((field) => !validFields.includes(field));
+  const invalidFields = fields.filter((field) => !validFieldSet.has(field));
 
   if (invalidFields.length > 0) {
-    return {
-      error: {
-        status: 400,
-        body: {
-          message: `${errorMessages.invalidFields[lang]} ${validFields.join(", ")}.`,
-          invalidFields,
-        },
+    return validationError(
+      `${errorMessages.invalidFields[lang]} ${formatValidFields()}`,
+      {
+        invalidFields,
       },
-    };
+    );
   }
 
   return { fields };
@@ -157,39 +173,18 @@ const parseFields = (rawFields, lang) => {
 
 const parsePagination = (pageParam, limitParam, lang) => {
   if (pageParam === "" || limitParam === "") {
-    return {
-      error: {
-        status: 400,
-        body: {
-          message: errorMessages.invalideParamettersPageLimit[lang],
-        },
-      },
-    };
+    return validationError(errorMessages.invalideParamettersPageLimit[lang]);
   }
 
-  const page = pageParam ? parseInt(pageParam, 10) : 0;
-  const limit = limitParam ? parseInt(limitParam, 10) : 50;
+  const page = pageParam ? Number.parseInt(pageParam, 10) : defaultPage;
+  const limit = limitParam ? Number.parseInt(limitParam, 10) : defaultLimit;
 
   if (pageParam && (!Number.isInteger(page) || page < 0)) {
-    return {
-      error: {
-        status: 400,
-        body: {
-          message: errorMessages.invalidPage[lang],
-        },
-      },
-    };
+    return validationError(errorMessages.invalidPage[lang]);
   }
 
   if (limitParam && (!Number.isInteger(limit) || limit < 1)) {
-    return {
-      error: {
-        status: 400,
-        body: {
-          message: errorMessages.invalidLimit[lang],
-        },
-      },
-    };
+    return validationError(errorMessages.invalidLimit[lang]);
   }
 
   return { page, limit };
@@ -206,11 +201,18 @@ const extractValues = (data, lang) => {
       }
       return item;
     })
-    .filter((item) => typeof item === "string" && item !== "en" && item !== "pt");
+    .filter(
+      (item) => typeof item === "string" && !excludedExtractedValues.has(item),
+    );
 };
 
 const localizeValue = (value, lang) => {
-  if (value && typeof value === "object" && !Array.isArray(value) && value[lang] !== undefined) {
+  if (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    value[lang] !== undefined
+  ) {
     return value[lang];
   }
 
@@ -222,48 +224,52 @@ const buildImagePaths = (exerciseId) => [
   `${exerciseId}/1.jpg`,
 ];
 
-const serializeExercise = (exercise, lang, fields, options = {}) => {
-  const imageFormatter = options.imageFormatter || ((currentExercise) => currentExercise.images);
-
-  if (fields) {
-    const result = {
-      _id: exercise._id,
-      name: localizeValue(exercise.name, lang),
-    };
-
-    fields.forEach((field) => {
-      if (field === "name") {
-        return;
-      }
-
-      if (field === "images") {
-        result.images = imageFormatter(exercise);
-        return;
-      }
-
-      if (exercise[field] !== undefined) {
-        result[field] = localizeValue(exercise[field], lang);
-      }
-    });
-
-    return result;
+const setSerializedField = (result, exercise, field, lang, imageFormatter) => {
+  if (field === "name") {
+    return;
   }
 
-  return {
-    ...exercise,
+  if (field === "images") {
+    result.images = imageFormatter(exercise);
+    return;
+  }
+
+  if (exercise[field] !== undefined) {
+    result[field] = localizeValue(exercise[field], lang);
+  }
+};
+
+const serializeSelectedFields = (exercise, lang, fields, imageFormatter) => {
+  const result = {
     _id: exercise._id,
     name: localizeValue(exercise.name, lang),
-    force: localizeValue(exercise.force, lang),
-    level: localizeValue(exercise.level, lang),
-    mechanic: localizeValue(exercise.mechanic, lang),
-    equipment: localizeValue(exercise.equipment, lang),
-    primaryMuscles: localizeValue(exercise.primaryMuscles, lang),
-    secondaryMuscles: localizeValue(exercise.secondaryMuscles, lang),
-    instructions: localizeValue(exercise.instructions, lang),
-    category: localizeValue(exercise.category, lang),
+  };
+
+  fields.forEach((field) =>
+    setSerializedField(result, exercise, field, lang, imageFormatter),
+  );
+  return result;
+};
+
+const serializeExercise = (exercise, lang, fields, options = {}) => {
+  const imageFormatter = options.imageFormatter || defaultImageFormatter;
+
+  if (fields) {
+    return serializeSelectedFields(exercise, lang, fields, imageFormatter);
+  }
+
+  const serializedExercise = {
+    ...exercise,
+    _id: exercise._id,
     images: imageFormatter(exercise),
     id: exercise.id,
   };
+
+  localizedExerciseFields.forEach((field) => {
+    serializedExercise[field] = localizeValue(exercise[field], lang);
+  });
+
+  return serializedExercise;
 };
 
 module.exports = {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,46 @@
+const js = require("@eslint/js");
+const prettier = require("eslint-config-prettier");
+
+const nodeGlobals = {
+  __dirname: "readonly",
+  Buffer: "readonly",
+  console: "readonly",
+  global: "readonly",
+  module: "readonly",
+  process: "readonly",
+  require: "readonly",
+};
+
+const jestGlobals = {
+  afterAll: "readonly",
+  afterEach: "readonly",
+  beforeAll: "readonly",
+  beforeEach: "readonly",
+  describe: "readonly",
+  expect: "readonly",
+  it: "readonly",
+  jest: "readonly",
+  test: "readonly",
+};
+
+module.exports = [
+  {
+    ignores: ["coverage/**", "dest/**", "node_modules/**"],
+  },
+  js.configs.recommended,
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: "commonjs",
+      globals: nodeGlobals,
+    },
+  },
+  {
+    files: ["test/**/*.js", "**/*.test.js", "**/*.spec.js"],
+    languageOptions: {
+      globals: jestGlobals,
+    },
+  },
+  prettier,
+];

--- a/test/routes/exercises.shared.test.js
+++ b/test/routes/exercises.shared.test.js
@@ -1,0 +1,221 @@
+const {
+  buildImagePaths,
+  defaultLanguage,
+  errorMessages,
+  extractValues,
+  getErrorLanguage,
+  getHeaderLanguage,
+  parseFields,
+  parseLanguage,
+  parsePagination,
+  serializeExercise,
+  supportedLanguages,
+  validFields,
+} = require("../../api/routes/exercises/shared");
+
+const exercise = {
+  _id: "exercise-id",
+  id: "Bench_Press",
+  name: {
+    en: "Bench Press",
+    pt: "Supino Reto",
+  },
+  force: {
+    en: "push",
+    pt: "empurrar",
+  },
+  level: {
+    en: "beginner",
+    pt: "iniciante",
+  },
+  mechanic: {
+    en: "compound",
+    pt: "composto",
+  },
+  equipment: {
+    en: "barbell",
+    pt: "barra",
+  },
+  primaryMuscles: {
+    en: ["chest"],
+    pt: ["peito"],
+  },
+  secondaryMuscles: {
+    en: ["triceps"],
+    pt: ["triceps"],
+  },
+  instructions: {
+    en: ["Lie on the bench.", "Press the bar up."],
+    pt: ["Deite no banco.", "Empurre a barra."],
+  },
+  category: {
+    en: "strength",
+    pt: "forca",
+  },
+  images: ["Bench_Press/0.jpg", "Bench_Press/1.jpg"],
+};
+
+describe("exercise shared helpers", () => {
+  describe("language parsing", () => {
+    it("uses the default language when no language is requested", () => {
+      expect(parseLanguage(undefined)).toEqual({ lang: defaultLanguage });
+    });
+
+    it("accepts supported requested languages", () => {
+      supportedLanguages.forEach((language) => {
+        expect(parseLanguage(language)).toEqual({ lang: language });
+      });
+    });
+
+    it("uses the accept-language header for invalid language error messages", () => {
+      const result = parseLanguage("es", "pt-BR,pt;q=0.9,en;q=0.8");
+
+      expect(result).toEqual({
+        error: {
+          status: 400,
+          body: {
+            message: errorMessages.invalidLang.pt,
+          },
+        },
+      });
+    });
+
+    it("falls back to the default language for unsupported accept-language headers", () => {
+      expect(getHeaderLanguage("es-ES,es;q=0.9")).toBe("es");
+      expect(getErrorLanguage("es", "es-ES,es;q=0.9")).toBe(defaultLanguage);
+    });
+  });
+
+  describe("field parsing", () => {
+    it("returns null fields when fields are not requested", () => {
+      expect(parseFields(undefined, "en")).toEqual({ fields: null });
+    });
+
+    it("trims requested fields", () => {
+      expect(parseFields(" name, equipment ,category ", "en")).toEqual({
+        fields: ["name", "equipment", "category"],
+      });
+    });
+
+    it("returns valid fields in the empty fields error", () => {
+      const result = parseFields("", "en");
+
+      expect(result.error.status).toBe(400);
+      expect(result.error.body.message).toBe(
+        `${errorMessages.invalideParametters.en} ${validFields.join(", ")}.`,
+      );
+    });
+
+    it("returns the invalid field names", () => {
+      const result = parseFields("name,unknown,badField", "en");
+
+      expect(result).toEqual({
+        error: {
+          status: 400,
+          body: {
+            message: `${errorMessages.invalidFields.en} ${validFields.join(", ")}.`,
+            invalidFields: ["unknown", "badField"],
+          },
+        },
+      });
+    });
+  });
+
+  describe("pagination parsing", () => {
+    it("uses default pagination values", () => {
+      expect(parsePagination(undefined, undefined, "en")).toEqual({
+        page: 0,
+        limit: 50,
+      });
+    });
+
+    it("parses valid pagination params", () => {
+      expect(parsePagination("2", "25", "en")).toEqual({
+        page: 2,
+        limit: 25,
+      });
+    });
+
+    it("rejects empty page or limit params", () => {
+      expect(parsePagination("", "10", "en").error.body.message).toBe(
+        errorMessages.invalideParamettersPageLimit.en,
+      );
+      expect(parsePagination("0", "", "pt").error.body.message).toBe(
+        errorMessages.invalideParamettersPageLimit.pt,
+      );
+    });
+
+    it("rejects negative page and zero limit values", () => {
+      expect(parsePagination("-1", "10", "en").error.body.message).toBe(
+        errorMessages.invalidPage.en,
+      );
+      expect(parsePagination("0", "0", "pt").error.body.message).toBe(
+        errorMessages.invalidLimit.pt,
+      );
+    });
+  });
+
+  describe("value extraction and images", () => {
+    it("extracts strings and localized object values from mixed data", () => {
+      const values = extractValues(
+        [["chest", "triceps"], { en: "push", pt: "empurrar" }, "en", "strength"],
+        "en",
+      );
+
+      expect(values).toEqual(["chest", "triceps", "push", "strength"]);
+    });
+
+    it("builds standard image paths", () => {
+      expect(buildImagePaths("Bench_Press")).toEqual([
+        "Bench_Press/0.jpg",
+        "Bench_Press/1.jpg",
+      ]);
+    });
+  });
+
+  describe("exercise serialization", () => {
+    it("localizes every translated field for full exercise responses", () => {
+      expect(serializeExercise(exercise, "pt", null)).toEqual({
+        ...exercise,
+        name: "Supino Reto",
+        force: "empurrar",
+        level: "iniciante",
+        mechanic: "composto",
+        equipment: "barra",
+        primaryMuscles: ["peito"],
+        secondaryMuscles: ["triceps"],
+        instructions: ["Deite no banco.", "Empurre a barra."],
+        category: "forca",
+        images: exercise.images,
+      });
+    });
+
+    it("returns _id and name with only requested fields", () => {
+      expect(serializeExercise(exercise, "en", ["equipment", "category"])).toEqual({
+        _id: "exercise-id",
+        name: "Bench Press",
+        equipment: "barbell",
+        category: "strength",
+      });
+    });
+
+    it("ignores repeated name requests because name is always included", () => {
+      expect(serializeExercise(exercise, "en", ["name"])).toEqual({
+        _id: "exercise-id",
+        name: "Bench Press",
+      });
+    });
+
+    it("uses a custom image formatter when serializing images", () => {
+      const result = serializeExercise(exercise, "en", ["images"], {
+        imageFormatter: (currentExercise) => buildImagePaths(currentExercise.id),
+      });
+
+      expect(result).toEqual({
+        _id: "exercise-id",
+        name: "Bench Press",
+        images: ["Bench_Press/0.jpg", "Bench_Press/1.jpg"],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Refactored `api/routes/exercises/shared.js` to reduce duplicated validation and serialization logic.
- Added ESLint 9 flat config with Node/CommonJS and Jest globals.
- Added focused unit tests for shared exercise route helpers.

## Changes

- Added reusable validation error helper for parser functions.
- Centralized pagination defaults and valid field formatting.
- Replaced repeated language/field membership checks with `Set`s.
- Extracted selected-field serialization into smaller helper functions.
- Centralized localized exercise fields used during full exercise serialization.
- Added `eslint.config.js` so `npm run lint` works with ESLint 9.
- Added `test/routes/exercises.shared.test.js` covering:
  - language parsing and fallback behavior
  - field parsing and invalid field reporting
  - pagination parsing
  - value extraction
  - image path generation
  - full and selected exercise serialization

## Validation

- `npm run lint`
- `npm test -- --runInBand`

Result: 4 test suites passed, 43 tests passed.
