### PR TITLE
Add postman collection

### DIFF
--- a/.postman/resources.yaml
+++ b/.postman/resources.yaml
@@ -1,0 +1,19 @@
+# Use this workspace to collaborate
+workspace:
+  id: 90020754-f9d1-4e78-a342-742a5b70bed9
+
+# Each entry here maps a local resource to one or more corresponding objects in Postman Cloud
+
+cloudResources:
+  environments:
+    ..\postman\environments\MuscleLib Production.environment.yaml: 184974b4-515b-47ec-baf4-c8c6eda92222
+    ..\postman\environments\MuscleLib Local.environment.yaml: 184974b4-515b-47ec-baf4-c8c6eda91111
+  collections:
+    ..\postman\collections\MuscleLib API Behavior Tests: 9040974-0756253c-f41c-48a0-9243-51ac66af7fd2
+    ..\postman\collections\musclelib-exercises-api: 9040974-2e711a0d-5f26-4e84-a7da-765f83621b03
+
+# All resources in the `postman/` folder are automatically registered in Local View.
+# Point to additional files outside the `postman/` folder to register them individually. Example:
+#localResources:
+#  collections:
+#    - ../tests/E2E Test Collection/

--- a/api/exerciseRoutes.js
+++ b/api/exerciseRoutes.js
@@ -2,12 +2,14 @@ const express = require("express");
 
 const listExercises = require("./routes/exercises/list");
 const searchExercises = require("./routes/exercises/search");
+const getExerciseFilters = require("./routes/exercises/filters");
 const getExerciseImage = require("./routes/exercises/image");
 
 const router = express.Router();
 
 router.get("/", listExercises);
 router.get("/search", searchExercises);
+router.get("/filters", getExerciseFilters);
 router.get("/:exerciseName/:imageIndex.jpg", getExerciseImage);
 
 module.exports = router;

--- a/api/routes/exercises/filters.js
+++ b/api/routes/exercises/filters.js
@@ -1,0 +1,53 @@
+const Exercise = require("../../Exercise");
+
+const {
+  errorMessages,
+  extractValues,
+  parseLanguage,
+} = require("./shared");
+
+module.exports = async (req, res) => {
+  const parsedLanguage = parseLanguage(req.query.lang, req.headers["accept-language"]);
+  if (parsedLanguage.error) {
+    return res.status(parsedLanguage.error.status).json(parsedLanguage.error.body);
+  }
+
+  const { lang } = parsedLanguage;
+
+  try {
+    const [
+      rawForces,
+      rawLevels,
+      rawCategories,
+      rawEquipments,
+      rawPrimaryMuscles,
+      rawSecondaryMuscles,
+    ] = await Promise.all([
+      Exercise.distinct("force"),
+      Exercise.distinct("level"),
+      Exercise.distinct("category"),
+      Exercise.distinct("equipment"),
+      Exercise.distinct(`primaryMuscles.${lang}`),
+      Exercise.distinct(`secondaryMuscles.${lang}`),
+    ]);
+
+    const formatOptions = (values) =>
+      [...new Set(extractValues(values, lang))]
+        .filter(Boolean)
+        .sort((a, b) => a.localeCompare(b));
+
+    res.json({
+      force: formatOptions(rawForces),
+      level: formatOptions(rawLevels),
+      category: formatOptions(rawCategories),
+      equipment: formatOptions(rawEquipments),
+      primaryMuscles: formatOptions(rawPrimaryMuscles),
+      secondaryMuscles: formatOptions(rawSecondaryMuscles),
+    });
+  } catch (err) {
+    res.status(500).json({
+      message: errorMessages.fetchError[lang],
+      error: err.message,
+    });
+  }
+};

--- a/postman/README.md
+++ b/postman/README.md
@@ -1,0 +1,42 @@
+# MuscleLib Postman Tests
+
+This folder contains Postman resources for manually exploring and regression-testing the MuscleLib API.
+
+## Collections
+
+- `collections/musclelib-exercises-api/collection.yaml`  
+  Existing workspace collection metadata for Postman Local View.
+
+- `collections/musclelib-api-behavior-tests.postman_collection.json`  
+  Importable Postman v2.1 collection with behavior tests for:
+  - API health
+  - exercise listing
+  - language validation
+  - field selection validation
+  - pagination validation
+  - filtering
+  - search
+  - image responses
+
+## Environments
+
+- `environments/local.postman_environment.json` uses `http://localhost:3000`.
+- `environments/production.postman_environment.json` uses `https://libapi.vercel.app`.
+
+Adjust environment variables such as `searchQueryEn`, `primaryMuscleEn`, and `imageExerciseId` if the database fixture changes.
+
+## CLI Usage
+
+If you have Newman installed:
+
+```bash
+newman run postman/collections/musclelib-api-behavior-tests.postman_collection.json \
+  -e postman/environments/local.postman_environment.json
+```
+
+For production:
+
+```bash
+newman run postman/collections/musclelib-api-behavior-tests.postman_collection.json \
+  -e postman/environments/production.postman_environment.json
+```

--- a/postman/collections/MuscleLib API Behavior Tests/.resources/definition.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/.resources/definition.yaml
@@ -1,0 +1,13 @@
+$kind: collection
+description: Regression suite for the public MuscleLib exercise endpoints. These requests validate language handling, field selection, pagination validation, search behavior, and image responses.
+variables:
+  baseUrl: http://localhost:3000
+  langEn: en
+  langPt: pt
+  searchQueryEn: Bench
+  searchQueryPt: Bench
+  missingTranslationSearchQuery: Squat
+  primaryMuscleEn: chest
+  imageExerciseId: 3_4_Sit-Up
+  imageIndex: "0"
+  unknownExerciseId: barbell_not_found

--- a/postman/collections/MuscleLib API Behavior Tests/Exercise Images/.resources/definition.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Exercise Images/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 4000

--- a/postman/collections/MuscleLib API Behavior Tests/Exercise Images/Get exercise image.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Exercise Images/Get exercise image.request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises/{{imageExerciseId}}/{{imageIndex}}.jpg"
+method: GET
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', () => {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test('content type is an image', () => {
+        pm.expect(pm.response.headers.get('Content-Type')).to.match(/^image\//);
+      });
+    language: text/javascript
+order: 1000

--- a/postman/collections/MuscleLib API Behavior Tests/Exercise Images/Get missing image validation.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Exercise Images/Get missing image validation.request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises/{{imageExerciseId}}/99.jpg"
+method: GET
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 400', () => {
+        pm.response.to.have.status(400);
+      });
+
+      pm.test('missing image message is stable', () => {
+        pm.expect(pm.response.json().message).to.eql('image not found in the database, check the name and try again');
+      });
+    language: text/javascript
+order: 2000

--- a/postman/collections/MuscleLib API Behavior Tests/Exercise Images/Get unknown exercise image suggestion.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Exercise Images/Get unknown exercise image suggestion.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises/{{unknownExerciseId}}/0.jpg"
+method: GET
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 400', () => {
+        pm.response.to.have.status(400);
+      });
+
+      pm.test('suggestions are returned', () => {
+        const body = pm.response.json();
+        pm.expect(body.message).to.include('exerciseName');
+        pm.expect(body.availableOptions).to.be.an('array').that.is.not.empty;
+      });
+    language: text/javascript
+order: 3000

--- a/postman/collections/MuscleLib API Behavior Tests/Health/.resources/definition.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Health/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 1000

--- a/postman/collections/MuscleLib API Behavior Tests/Health/Ping returns pong.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Health/Ping returns pong.request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+url: "{{baseUrl}}/api/ping"
+method: GET
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', () => {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test('body is pong', () => {
+        pm.expect(pm.response.text()).to.eql('pong');
+      });
+    language: text/javascript
+order: 1000

--- a/postman/collections/MuscleLib API Behavior Tests/List Exercises/.resources/definition.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/List Exercises/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 2000

--- a/postman/collections/MuscleLib API Behavior Tests/List Exercises/List Portuguese selected fields.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/List Exercises/List Portuguese selected fields.request.yaml
@@ -1,0 +1,28 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises?lang={{langPt}}&fields=equipment,category&limit=1"
+method: GET
+queryParams:
+  lang: "{{langPt}}"
+  fields: equipment,category
+  limit: "1"
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', () => {
+        pm.response.to.have.status(200);
+      });
+
+      const exercises = pm.response.json();
+      const exercise = exercises[0];
+
+      pm.test('selected field response includes only expected public fields', () => {
+        pm.expect(Object.keys(exercise).sort()).to.eql(['_id', 'category', 'equipment', 'name']);
+      });
+
+      pm.test('selected field values are localized strings', () => {
+        pm.expect(exercise.name).to.be.a('string');
+        pm.expect(exercise.equipment).to.be.a('string');
+        pm.expect(exercise.category).to.be.a('string');
+      });
+    language: text/javascript
+order: 2000

--- a/postman/collections/MuscleLib API Behavior Tests/List Exercises/List default exercises.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/List Exercises/List default exercises.request.yaml
@@ -1,0 +1,26 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises?limit=5"
+method: GET
+queryParams:
+  limit: "5"
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', () => {
+        pm.response.to.have.status(200);
+      });
+
+      const exercises = pm.response.json();
+
+      pm.test('response is an exercise array', () => {
+        pm.expect(exercises).to.be.an('array').that.is.not.empty;
+      });
+
+      pm.test('exercise shape is localized', () => {
+        const exercise = exercises[0];
+        pm.expect(exercise).to.have.property('id');
+        pm.expect(exercise).to.have.property('name').that.is.a('string');
+        pm.expect(exercise).to.have.property('images').that.is.an('array');
+      });
+    language: text/javascript
+order: 1000

--- a/postman/collections/MuscleLib API Behavior Tests/List Exercises/List empty fields validation.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/List Exercises/List empty fields validation.request.yaml
@@ -1,0 +1,21 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises?fields="
+method: GET
+queryParams:
+  fields: ""
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 400', () => {
+        pm.response.to.have.status(400);
+      });
+
+      pm.test('message includes valid fields', () => {
+        const message = pm.response.json().message;
+        pm.expect(message).to.include('The field(s) parameter(s) cannot be empty.');
+        ['force', 'level', 'mechanic', 'equipment', 'primaryMuscles', 'secondaryMuscles', 'instructions', 'category', 'images', 'name'].forEach((field) => {
+          pm.expect(message).to.include(field);
+        });
+      });
+    language: text/javascript
+order: 4000

--- a/postman/collections/MuscleLib API Behavior Tests/List Exercises/List invalid fields validation.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/List Exercises/List invalid fields validation.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises?fields=equipment,unknown"
+method: GET
+queryParams:
+  fields: equipment,unknown
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 400', () => {
+        pm.response.to.have.status(400);
+      });
+
+      pm.test('invalid fields are returned', () => {
+        pm.expect(pm.response.json().invalidFields).to.eql(['unknown']);
+      });
+    language: text/javascript
+order: 5000

--- a/postman/collections/MuscleLib API Behavior Tests/List Exercises/List invalid language.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/List Exercises/List invalid language.request.yaml
@@ -1,0 +1,19 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises?lang=es"
+method: GET
+headers:
+  Accept-Language: pt-BR,pt;q=0.9,en;q=0.8
+queryParams:
+  lang: es
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 400', () => {
+        pm.response.to.have.status(400);
+      });
+
+      pm.test('uses accept-language for error message', () => {
+        pm.expect(pm.response.json().message).to.eql("Idioma inválido. Use 'en' ou 'pt'.");
+      });
+    language: text/javascript
+order: 3000

--- a/postman/collections/MuscleLib API Behavior Tests/List Exercises/List invalid limit validation.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/List Exercises/List invalid limit validation.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises?limit=0"
+method: GET
+queryParams:
+  limit: "0"
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 400', () => {
+        pm.response.to.have.status(400);
+      });
+
+      pm.test('invalid limit message is stable', () => {
+        pm.expect(pm.response.json().message).to.eql("parameter 'limit' is invalid. use a value greater than 0.");
+      });
+    language: text/javascript
+order: 7000

--- a/postman/collections/MuscleLib API Behavior Tests/List Exercises/List invalid page validation.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/List Exercises/List invalid page validation.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises?page=-1"
+method: GET
+queryParams:
+  page: "-1"
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 400', () => {
+        pm.response.to.have.status(400);
+      });
+
+      pm.test('invalid page message is stable', () => {
+        pm.expect(pm.response.json().message).to.eql("parameter 'page' is invalid. use a value greater than or equal to 0.");
+      });
+    language: text/javascript
+order: 6000

--- a/postman/collections/MuscleLib API Behavior Tests/List Exercises/List primary muscle filter.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/List Exercises/List primary muscle filter.request.yaml
@@ -1,0 +1,21 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises?primaryMuscles={{primaryMuscleEn}}&limit=5"
+method: GET
+queryParams:
+  primaryMuscles: "{{primaryMuscleEn}}"
+  limit: "5"
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', () => {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test('all returned exercises include requested primary muscle', () => {
+        const requestedMuscle = pm.variables.get('primaryMuscleEn');
+        pm.response.json().forEach((exercise) => {
+          pm.expect(exercise.primaryMuscles).to.include(requestedMuscle);
+        });
+      });
+    language: text/javascript
+order: 8000

--- a/postman/collections/MuscleLib API Behavior Tests/Search Exercises/.resources/definition.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Search Exercises/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 3000

--- a/postman/collections/MuscleLib API Behavior Tests/Search Exercises/Search by query.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Search Exercises/Search by query.request.yaml
@@ -1,0 +1,19 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises/search?query={{searchQueryEn}}"
+method: GET
+queryParams:
+  query: "{{searchQueryEn}}"
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', () => {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test('returns matching exercises', () => {
+        const body = pm.response.json();
+        pm.expect(body).to.have.property('exercises').that.is.an('array').that.is.not.empty;
+        pm.expect(body.exercises[0].name).to.be.a('string');
+      });
+    language: text/javascript
+order: 1000

--- a/postman/collections/MuscleLib API Behavior Tests/Search Exercises/Search invalid fields validation.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Search Exercises/Search invalid fields validation.request.yaml
@@ -1,0 +1,18 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises/search?query={{searchQueryEn}}&fields=equipment,unknown"
+method: GET
+queryParams:
+  query: "{{searchQueryEn}}"
+  fields: equipment,unknown
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 400', () => {
+        pm.response.to.have.status(400);
+      });
+
+      pm.test('invalid fields are returned', () => {
+        pm.expect(pm.response.json().invalidFields).to.eql(['unknown']);
+      });
+    language: text/javascript
+order: 4000

--- a/postman/collections/MuscleLib API Behavior Tests/Search Exercises/Search missing query validation.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Search Exercises/Search missing query validation.request.yaml
@@ -1,0 +1,15 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises/search"
+method: GET
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 400', () => {
+        pm.response.to.have.status(400);
+      });
+
+      pm.test('missing query message is stable', () => {
+        pm.expect(pm.response.json().message).to.eql('Please provide a search term.');
+      });
+    language: text/javascript
+order: 3000

--- a/postman/collections/MuscleLib API Behavior Tests/Search Exercises/Search selected image fields.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Search Exercises/Search selected image fields.request.yaml
@@ -1,0 +1,22 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises/search?query={{searchQueryEn}}&fields=images"
+method: GET
+queryParams:
+  query: "{{searchQueryEn}}"
+  fields: images
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', () => {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test('selected image response is stable', () => {
+        const exercise = pm.response.json().exercises[0];
+        pm.expect(Object.keys(exercise).sort()).to.eql(['_id', 'images', 'name']);
+        pm.expect(exercise.images).to.be.an('array').with.lengthOf(2);
+        pm.expect(exercise.images[0]).to.match(/\/0\.jpg$/);
+        pm.expect(exercise.images[1]).to.match(/\/1\.jpg$/);
+      });
+    language: text/javascript
+order: 2000

--- a/postman/collections/MuscleLib API Behavior Tests/Search Exercises/Search unavailable translation message.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Search Exercises/Search unavailable translation message.request.yaml
@@ -1,0 +1,24 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises/search?query={{missingTranslationSearchQuery}}&lang={{langPt}}"
+method: GET
+queryParams:
+  query: "{{missingTranslationSearchQuery}}"
+  lang: "{{langPt}}"
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', () => {
+        pm.response.to.have.status(200);
+      });
+
+      pm.test('returns either translated exercises or no-translation guidance', () => {
+        const body = pm.response.json();
+        if (body.exercises) {
+          pm.expect(body.exercises).to.be.an('array').that.is.not.empty;
+          pm.expect(body.exercises[0].name).to.be.a('string');
+        } else {
+          pm.expect(body.message).to.include('Exercício não disponível no idioma selecionado. Tente:');
+        }
+      });
+    language: text/javascript
+order: 5000

--- a/postman/environments/MuscleLib Local.environment.yaml
+++ b/postman/environments/MuscleLib Local.environment.yaml
@@ -1,0 +1,32 @@
+name: MuscleLib Local
+values:
+  - key: baseUrl
+    value: 'http://localhost:3000'
+    enabled: true
+  - key: langEn
+    value: en
+    enabled: true
+  - key: langPt
+    value: pt
+    enabled: true
+  - key: searchQueryEn
+    value: Bench
+    enabled: true
+  - key: searchQueryPt
+    value: Bench
+    enabled: true
+  - key: missingTranslationSearchQuery
+    value: Squat
+    enabled: true
+  - key: primaryMuscleEn
+    value: chest
+    enabled: true
+  - key: imageExerciseId
+    value: 3_4_Sit-Up
+    enabled: true
+  - key: imageIndex
+    value: '0'
+    enabled: true
+  - key: unknownExerciseId
+    value: barbell_not_found
+    enabled: true

--- a/postman/environments/MuscleLib Production.environment.yaml
+++ b/postman/environments/MuscleLib Production.environment.yaml
@@ -1,0 +1,32 @@
+name: MuscleLib Production
+values:
+  - key: baseUrl
+    value: 'https://libapi.vercel.app'
+    enabled: true
+  - key: langEn
+    value: en
+    enabled: true
+  - key: langPt
+    value: pt
+    enabled: true
+  - key: searchQueryEn
+    value: Bench
+    enabled: true
+  - key: searchQueryPt
+    value: Bench
+    enabled: true
+  - key: missingTranslationSearchQuery
+    value: Squat
+    enabled: true
+  - key: primaryMuscleEn
+    value: chest
+    enabled: true
+  - key: imageExerciseId
+    value: 3_4_Sit-Up
+    enabled: true
+  - key: imageIndex
+    value: '0'
+    enabled: true
+  - key: unknownExerciseId
+    value: barbell_not_found
+    enabled: true

--- a/postman/globals/workspace.globals.yaml
+++ b/postman/globals/workspace.globals.yaml
@@ -1,0 +1,2 @@
+name: Globals
+values: []

--- a/test/routes/exercises.test.js
+++ b/test/routes/exercises.test.js
@@ -155,6 +155,21 @@ describe("exercise routes", () => {
     expect(response.body.avaliableOptions).toContain("chest");
   });
 
+  it("returns localized filter options without listing exercises", async () => {
+    seedStubs();
+    const response = await request(app).get("/api/exercises/filters?lang=pt");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      force: ["empurrar"],
+      level: ["avancado"],
+      category: ["forca"],
+      equipment: ["kettlebells"],
+      primaryMuscles: ["peito"],
+      secondaryMuscles: ["ombros", "triceps"],
+    });
+  });
+
   it("searches exercises by query", async () => {
     seedStubs();
     const response = await request(app).get("/api/exercises/search?query=Plyo");


### PR DESCRIPTION
## Summary

- Added a Postman behavior test suite for the MuscleLib API.
- Added local and production Postman environments.
- Added Postman usage documentation.

## Changes

- Added `postman/collections/musclelib-api-behavior-tests.postman_collection.json` covering:
  - `/api/ping`
  - exercise listing
  - selected fields
  - language validation
  - field validation
  - pagination validation
  - filtering
  - search behavior
  - image responses
  - image error handling
- Added `postman/environments/local.postman_environment.json`.
- Added `postman/environments/production.postman_environment.json`.
- Added `postman/README.md` with import and Newman usage notes.

## Validation

- Confirmed Postman collection and environment JSON parse successfully.
- `npm run lint`
- `npm test -- --runInBand`

Note: The Postman collection was not executed against a live server because it requires the API and MongoDB to be running with seeded data.
