### PR TITLE
Update database to include enumerated collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dist
 .yarn/install-state.gz
 .pnp.*
 .vercel
+
+# Claude AI
+.claude

--- a/.postman/resources.yaml
+++ b/.postman/resources.yaml
@@ -1,19 +1,11 @@
-# Use this workspace to collaborate
 workspace:
   id: 90020754-f9d1-4e78-a342-742a5b70bed9
-
-# Each entry here maps a local resource to one or more corresponding objects in Postman Cloud
-
 cloudResources:
   environments:
     ..\postman\environments\MuscleLib Production.environment.yaml: 184974b4-515b-47ec-baf4-c8c6eda92222
     ..\postman\environments\MuscleLib Local.environment.yaml: 184974b4-515b-47ec-baf4-c8c6eda91111
+    ../postman/environments/MuscleLib Local.environment.yaml: 9040974-184974b4-515b-47ec-baf4-c8c6eda91111
+    ../postman/environments/MuscleLib Production.environment.yaml: 9040974-184974b4-515b-47ec-baf4-c8c6eda92222
   collections:
     ..\postman\collections\MuscleLib API Behavior Tests: 9040974-0756253c-f41c-48a0-9243-51ac66af7fd2
     ..\postman\collections\musclelib-exercises-api: 9040974-2e711a0d-5f26-4e84-a7da-765f83621b03
-
-# All resources in the `postman/` folder are automatically registered in Local View.
-# Point to additional files outside the `postman/` folder to register them individually. Example:
-#localResources:
-#  collections:
-#    - ../tests/E2E Test Collection/

--- a/api/Translation.js
+++ b/api/Translation.js
@@ -1,0 +1,16 @@
+const mongoose = require("mongoose")
+
+const translationSchema = new mongoose.Schema({
+  key: { type: String, required: true, unique: true },
+  translations: {
+    en: String,
+    pt: String,
+    es: String,
+  },
+})
+
+const translationModel = (collection) =>
+  mongoose.models[collection] ||
+  mongoose.model(collection, translationSchema, collection)
+
+module.exports = translationModel

--- a/api/routes/exercises/filters.js
+++ b/api/routes/exercises/filters.js
@@ -1,10 +1,19 @@
-const Exercise = require("../../Exercise");
+const translationModel = require("../../Translation");
+const { errorMessages, parseLanguage } = require("./shared");
 
-const {
-  errorMessages,
-  extractValues,
-  parseLanguage,
-} = require("./shared");
+const ForceTranslation = translationModel("force_translations");
+const LevelTranslation = translationModel("level_translations");
+const CategoryTranslation = translationModel("category_translations");
+const EquipmentTranslation = translationModel("equipment_translations");
+const MuscleTranslation = translationModel("muscle_translations");
+
+const getTranslations = async (model, lang) => {
+  const docs = await model.find({}, { translations: 1, _id: 0 });
+  return docs
+    .map((doc) => doc.translations?.[lang])
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b));
+};
 
 module.exports = async (req, res) => {
   const parsedLanguage = parseLanguage(req.query.lang, req.headers["accept-language"]);
@@ -15,34 +24,21 @@ module.exports = async (req, res) => {
   const { lang } = parsedLanguage;
 
   try {
-    const [
-      rawForces,
-      rawLevels,
-      rawCategories,
-      rawEquipments,
-      rawPrimaryMuscles,
-      rawSecondaryMuscles,
-    ] = await Promise.all([
-      Exercise.distinct("force"),
-      Exercise.distinct("level"),
-      Exercise.distinct("category"),
-      Exercise.distinct("equipment"),
-      Exercise.distinct(`primaryMuscles.${lang}`),
-      Exercise.distinct(`secondaryMuscles.${lang}`),
+    const [force, level, category, equipment, muscles] = await Promise.all([
+      getTranslations(ForceTranslation, lang),
+      getTranslations(LevelTranslation, lang),
+      getTranslations(CategoryTranslation, lang),
+      getTranslations(EquipmentTranslation, lang),
+      getTranslations(MuscleTranslation, lang),
     ]);
 
-    const formatOptions = (values) =>
-      [...new Set(extractValues(values, lang))]
-        .filter(Boolean)
-        .sort((a, b) => a.localeCompare(b));
-
     res.json({
-      force: formatOptions(rawForces),
-      level: formatOptions(rawLevels),
-      category: formatOptions(rawCategories),
-      equipment: formatOptions(rawEquipments),
-      primaryMuscles: formatOptions(rawPrimaryMuscles),
-      secondaryMuscles: formatOptions(rawSecondaryMuscles),
+      force,
+      level,
+      category,
+      equipment,
+      primaryMuscles: muscles,
+      secondaryMuscles: muscles,
     });
   } catch (err) {
     res.status(500).json({

--- a/postman/collections/MuscleLib API Behavior Tests/Filters/.resources/definition.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Filters/.resources/definition.yaml
@@ -1,0 +1,2 @@
+$kind: collection
+order: 3000

--- a/postman/collections/MuscleLib API Behavior Tests/Filters/Get filters in English.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Filters/Get filters in English.request.yaml
@@ -1,0 +1,35 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises/filters?lang={{langEn}}"
+method: GET
+queryParams:
+  lang: "{{langEn}}"
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', () => {
+        pm.response.to.have.status(200);
+      });
+
+      const body = pm.response.json();
+
+      pm.test('response has all filter keys', () => {
+        pm.expect(body).to.have.all.keys('force', 'level', 'category', 'equipment', 'primaryMuscles', 'secondaryMuscles');
+      });
+
+      pm.test('all filter values are arrays of strings', () => {
+        ['force', 'level', 'category', 'equipment', 'primaryMuscles', 'secondaryMuscles'].forEach((key) => {
+          pm.expect(body[key]).to.be.an('array').that.is.not.empty;
+          body[key].forEach((value) => {
+            pm.expect(value).to.be.a('string');
+          });
+        });
+      });
+
+      pm.test('results are sorted alphabetically', () => {
+        ['force', 'level', 'category', 'equipment', 'primaryMuscles', 'secondaryMuscles'].forEach((key) => {
+          const sorted = [...body[key]].sort((a, b) => a.localeCompare(b));
+          pm.expect(body[key]).to.eql(sorted);
+        });
+      });
+    language: text/javascript
+order: 1000

--- a/postman/collections/MuscleLib API Behavior Tests/Filters/Get filters in Portuguese.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Filters/Get filters in Portuguese.request.yaml
@@ -1,0 +1,29 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises/filters?lang={{langPt}}"
+method: GET
+queryParams:
+  lang: "{{langPt}}"
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 200', () => {
+        pm.response.to.have.status(200);
+      });
+
+      const body = pm.response.json();
+
+      pm.test('response has all filter keys', () => {
+        pm.expect(body).to.have.all.keys('force', 'level', 'category', 'equipment', 'primaryMuscles', 'secondaryMuscles');
+      });
+
+      pm.test('all filter values are non-empty arrays', () => {
+        ['force', 'level', 'category', 'equipment', 'primaryMuscles', 'secondaryMuscles'].forEach((key) => {
+          pm.expect(body[key]).to.be.an('array').that.is.not.empty;
+        });
+      });
+
+      pm.test('primaryMuscles and secondaryMuscles return the same list', () => {
+        pm.expect(body.primaryMuscles).to.eql(body.secondaryMuscles);
+      });
+    language: text/javascript
+order: 2000

--- a/postman/collections/MuscleLib API Behavior Tests/Filters/Get filters invalid language.request.yaml
+++ b/postman/collections/MuscleLib API Behavior Tests/Filters/Get filters invalid language.request.yaml
@@ -1,0 +1,17 @@
+$kind: http-request
+url: "{{baseUrl}}/api/exercises/filters?lang=es"
+method: GET
+queryParams:
+  lang: "es"
+scripts:
+  - type: afterResponse
+    code: |-
+      pm.test('status is 400', () => {
+        pm.response.to.have.status(400);
+      });
+
+      pm.test('error message mentions valid languages', () => {
+        pm.expect(pm.response.json().message).to.include("'en'").and.to.include("'pt'");
+      });
+    language: text/javascript
+order: 3000

--- a/scripts/seed-translations.js
+++ b/scripts/seed-translations.js
@@ -1,0 +1,120 @@
+// Run with: mongosh '<connection-string>/<db-name>' --file scripts/seed-translations.js
+// Example:  mongosh 'mongodb+srv://user:pass@cluster0.xyz.mongodb.net/musclelib' --file scripts/seed-translations.js
+
+try {
+  db.runCommand({ ping: 1 })
+  print(`✔ Connected to MongoDB successfully (database: "${db.getName()}")`)
+} catch (e) {
+  print("✖ Failed to connect to MongoDB: " + e.message)
+  quit(1)
+}
+
+const sourceCollection = db.exercises
+const sourceCount = sourceCollection.countDocuments()
+
+if (sourceCount === 0) {
+  print(`✖ No documents found in "${db.getName()}.exercises" — make sure the database name is correct in the connection string`)
+  quit(1)
+}
+
+print(`✔ Found ${sourceCount} exercises in "${db.getName()}.exercises"`)
+
+function normalizeKey(value) {
+  if (!value || typeof value !== "string") return null
+
+  return value
+    .toLowerCase()
+    .replace(/\s+/g, "_")
+    .replace(/[^\w]/g, "")
+}
+
+function insertTranslations(targetCollection, values) {
+  const uniqueMap = new Map()
+
+  values.forEach(item => {
+    if (!item?.en || !item?.pt) return
+    if (typeof item.en !== "string" || typeof item.pt !== "string") return
+
+    const key = normalizeKey(item.en)
+
+    if (!uniqueMap.has(key)) {
+      uniqueMap.set(key, {
+        key,
+        translations: {
+          en: item.en,
+          pt: item.pt,
+          es: item.en
+        }
+      })
+    }
+  })
+
+  const docs = Array.from(uniqueMap.values())
+
+  if (docs.length === 0) return
+
+  db[targetCollection].createIndex({ key: 1 }, { unique: true })
+
+  const ops = docs.map(doc => ({
+    replaceOne: {
+      filter: { key: doc.key },
+      replacement: doc,
+      upsert: true
+    }
+  }))
+
+  const result = db[targetCollection].bulkWrite(ops, { ordered: false })
+
+  print(`✔ ${targetCollection}: ${result.upsertedCount} inserted, ${result.modifiedCount} updated`)
+}
+
+const equipment = []
+const force = []
+const level = []
+const mechanic = []
+const category = []
+const muscles = []
+
+sourceCollection.find().forEach(doc => {
+
+  if (doc.equipment?.en && doc.equipment?.pt) {
+    equipment.push({ en: doc.equipment.en, pt: doc.equipment.pt })
+  }
+
+  if (doc.force?.en && doc.force?.pt) {
+    force.push({ en: doc.force.en, pt: doc.force.pt })
+  }
+
+  if (doc.level?.en && doc.level?.pt) {
+    level.push({ en: doc.level.en, pt: doc.level.pt })
+  }
+
+  if (doc.mechanic?.en && doc.mechanic?.pt) {
+    mechanic.push({ en: doc.mechanic.en, pt: doc.mechanic.pt })
+  }
+
+  if (doc.category?.en && doc.category?.pt) {
+    category.push({ en: doc.category.en, pt: doc.category.pt })
+  }
+
+  if (Array.isArray(doc.primaryMuscles?.en) && Array.isArray(doc.primaryMuscles?.pt)) {
+    doc.primaryMuscles.en.forEach((muscle, index) => {
+      muscles.push({ en: muscle, pt: doc.primaryMuscles.pt[index] })
+    })
+  }
+
+  if (Array.isArray(doc.secondaryMuscles?.en) && Array.isArray(doc.secondaryMuscles?.pt)) {
+    doc.secondaryMuscles.en.forEach((muscle, index) => {
+      muscles.push({ en: muscle, pt: doc.secondaryMuscles.pt[index] })
+    })
+  }
+})
+
+insertTranslations("equipment_translations", equipment)
+insertTranslations("force_translations", force)
+insertTranslations("level_translations", level)
+insertTranslations("mechanic_translations", mechanic)
+insertTranslations("category_translations", category)
+insertTranslations("muscle_translations", muscles)
+
+print("✅ Translation collections seeded successfully")

--- a/test/routes/exercises.filters.test.js
+++ b/test/routes/exercises.filters.test.js
@@ -1,0 +1,102 @@
+const express = require("express");
+const request = require("supertest");
+const mongoose = require("mongoose");
+const exerciseRoutes = require("../../api/exerciseRoutes");
+
+describe("GET /api/exercises/filters", () => {
+  let app;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use("/api/exercises", exerciseRoutes);
+  });
+
+  const seedTranslationStubs = ({
+    force = [{ translations: { en: "push", pt: "empurrar" } }],
+    level = [{ translations: { en: "beginner", pt: "iniciante" } }],
+    category = [{ translations: { en: "strength", pt: "forca" } }],
+    equipment = [{ translations: { en: "barbell", pt: "barra" } }],
+    muscles = [
+      { translations: { en: "chest", pt: "peito" } },
+      { translations: { en: "triceps", pt: "triceps" } },
+    ],
+  } = {}) => {
+    mongoose.models.force_translations.find = jest.fn().mockResolvedValue(force);
+    mongoose.models.level_translations.find = jest.fn().mockResolvedValue(level);
+    mongoose.models.category_translations.find = jest.fn().mockResolvedValue(category);
+    mongoose.models.equipment_translations.find = jest.fn().mockResolvedValue(equipment);
+    mongoose.models.muscle_translations.find = jest.fn().mockResolvedValue(muscles);
+  };
+
+  it("returns 400 for invalid language", async () => {
+    const response = await request(app).get("/api/exercises/filters?lang=es");
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Invalid language. Use 'en' or 'pt'.");
+  });
+
+  it("returns all filter keys in English", async () => {
+    seedTranslationStubs();
+    const response = await request(app).get("/api/exercises/filters?lang=en");
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      force: ["push"],
+      level: ["beginner"],
+      category: ["strength"],
+      equipment: ["barbell"],
+      primaryMuscles: expect.any(Array),
+      secondaryMuscles: expect.any(Array),
+    });
+  });
+
+  it("returns translated values in Portuguese", async () => {
+    seedTranslationStubs();
+    const response = await request(app).get("/api/exercises/filters?lang=pt");
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      force: ["empurrar"],
+      level: ["iniciante"],
+      category: ["forca"],
+      equipment: ["barra"],
+      primaryMuscles: ["peito", "triceps"],
+      secondaryMuscles: ["peito", "triceps"],
+    });
+  });
+
+  it("defaults to English when lang is not provided", async () => {
+    seedTranslationStubs();
+    const response = await request(app).get("/api/exercises/filters");
+    expect(response.status).toBe(200);
+    expect(response.body.force).toEqual(["push"]);
+  });
+
+  it("returns results sorted alphabetically", async () => {
+    seedTranslationStubs({
+      muscles: [
+        { translations: { en: "triceps", pt: "triceps" } },
+        { translations: { en: "abs", pt: "abdomen" } },
+        { translations: { en: "chest", pt: "peito" } },
+      ],
+    });
+    const response = await request(app).get("/api/exercises/filters?lang=en");
+    expect(response.status).toBe(200);
+    expect(response.body.primaryMuscles).toEqual(["abs", "chest", "triceps"]);
+  });
+
+  it("returns the same list for primaryMuscles and secondaryMuscles", async () => {
+    seedTranslationStubs();
+    const response = await request(app).get("/api/exercises/filters");
+    expect(response.status).toBe(200);
+    expect(response.body.primaryMuscles).toEqual(response.body.secondaryMuscles);
+  });
+
+  it("returns 500 on database error", async () => {
+    mongoose.models.force_translations.find = jest
+      .fn()
+      .mockRejectedValue(new Error("DB connection lost"));
+    const response = await request(app).get("/api/exercises/filters");
+    expect(response.status).toBe(500);
+    expect(response.body.message).toBe("Error fetching exercises.");
+    expect(response.body.error).toBe("DB connection lost");
+  });
+});

--- a/test/routes/exercises.test.js
+++ b/test/routes/exercises.test.js
@@ -2,6 +2,7 @@ const express = require("express");
 const request = require("supertest");
 
 const fs = require("fs");
+const mongoose = require("mongoose");
 const Exercise = require("../../api/Exercise");
 const exerciseRoutes = require("../../api/exerciseRoutes");
 const { buildExercise, exercisesFixture } = require("../fixtures/exercises.fixture");
@@ -156,7 +157,22 @@ describe("exercise routes", () => {
   });
 
   it("returns localized filter options without listing exercises", async () => {
-    seedStubs();
+    mongoose.models.force_translations.find = jest
+      .fn()
+      .mockResolvedValue([{ translations: { en: "push", pt: "empurrar" } }]);
+    mongoose.models.level_translations.find = jest
+      .fn()
+      .mockResolvedValue([{ translations: { en: "expert", pt: "avancado" } }]);
+    mongoose.models.category_translations.find = jest
+      .fn()
+      .mockResolvedValue([{ translations: { en: "strength", pt: "forca" } }]);
+    mongoose.models.equipment_translations.find = jest
+      .fn()
+      .mockResolvedValue([{ translations: { en: "kettlebells", pt: "kettlebells" } }]);
+    mongoose.models.muscle_translations.find = jest
+      .fn()
+      .mockResolvedValue([{ translations: { en: "chest", pt: "peito" } }]);
+
     const response = await request(app).get("/api/exercises/filters?lang=pt");
 
     expect(response.status).toBe(200);
@@ -166,7 +182,7 @@ describe("exercise routes", () => {
       category: ["forca"],
       equipment: ["kettlebells"],
       primaryMuscles: ["peito"],
-      secondaryMuscles: ["ombros", "triceps"],
+      secondaryMuscles: ["peito"],
     });
   });
 


### PR DESCRIPTION
## Translation-based filter collections

### Summary

- **Seed script** (`scripts/seed-translations.js`): extracts unique `equipment`, `force`, `level`, `mechanic`, `category`, and `muscle` values from the `exercises` collection and upserts them into dedicated `*_translations` collections. Each document stores a normalized `key` and a `translations` object (`en`, `pt`, `es`). The script is idempotent (uses `bulkWrite` + upsert), validates the MongoDB connection on startup, and exits early if the source collection is empty.

- **Translation model** (`api/Translation.js`): shared Mongoose model factory for the translation collections. Uses `mongoose.models` cache to avoid re-registering models across requires.

- **Filters endpoint** (`api/routes/exercises/filters.js`): rewritten to read from the five translation collections instead of running `distinct` on the `exercises` collection. Each collection is queried in parallel; values are plucked by language and sorted. Response shape is unchanged — `primaryMuscles` and `secondaryMuscles` both return the full `muscle_translations` list.

- **Tests** (`test/routes/exercises.filters.test.js`): new dedicated test suite with 7 cases covering English/Portuguese responses, alphabetical sorting, `primaryMuscles === secondaryMuscles` invariant, default language fallback, and 500 error handling. Existing `exercises.test.js` filters test updated to mock `mongoose.models.*_translations.find` instead of the now-unused `Exercise.distinct`.

- **Postman** (`postman/collections/.../Filters/`): new folder with three requests — English filters (validates shape, string values, sort order), Portuguese filters (validates shape and muscle list symmetry), and invalid language (validates 400 + error message).

### Test plan

- [x] Run seed script against the real DB and verify the six collections are populated with no `null`-key documents
- [x] `GET /api/exercises/filters?lang=en` returns non-empty arrays for all six keys
- [x] `GET /api/exercises/filters?lang=pt` returns Portuguese translations
- [x] `GET /api/exercises/filters?lang=es` returns 400
- [x] Re-running the seed script produces the same results (idempotency)
- [x] Full Jest suite passes: `npx jest --no-coverage`
- [x] Newman run against local env passes all Postman Filters requests